### PR TITLE
Make GitHub detect *.tbf1 as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tbf1 linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.tbf1` files as Forth.

Thanks!
